### PR TITLE
Replacing spaces in library name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,4 @@
-﻿name=SparkFun SCD30 Arduino Library
-name=SparkFun SCD30 Arduino Library
+name=SparkFun_SCD30_Arduino_Library
 version=1.0.3
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>


### PR DESCRIPTION
This would allow particle.io integration with no other modification.
I have tested the lib to work on Particle Mesh and default I2C config.

Fixes #4 