### PR TITLE
Add error handling and remove WProgram.h include

### DIFF
--- a/src/SparkFun_SCD30_Arduino_Library.h
+++ b/src/SparkFun_SCD30_Arduino_Library.h
@@ -27,11 +27,7 @@
 
 #pragma once
 
-#if (ARDUINO >= 100)
 #include "Arduino.h"
-#else
-#include "WProgram.h"
-#endif
 
 #include <Wire.h>
 

--- a/src/SparkFun_SCD30_Arduino_Library.h
+++ b/src/SparkFun_SCD30_Arduino_Library.h
@@ -59,12 +59,12 @@ class SCD30
 	float getHumidity(void);
 	float getTemperature(void);
 
-	void setMeasurementInterval(uint16_t interval);
-	void setAmbientPressure(uint16_t pressure_mbar);
-	void setAltitudeCompensation(uint16_t altitude);
-	void setAutoSelfCalibration(boolean enable);
-	void setForcedRecalibrationFactor(uint16_t concentration);
-	void setTemperatureOffset(float tempOffset);
+	bool setMeasurementInterval(uint16_t interval);
+	bool setAmbientPressure(uint16_t pressure_mbar);
+	bool setAltitudeCompensation(uint16_t altitude);
+	bool setAutoSelfCalibration(boolean enable);
+	bool setForcedRecalibrationFactor(uint16_t concentration);
+	bool setTemperatureOffset(float tempOffset);
 
 	boolean dataAvailable();
 	boolean readMeasurement();


### PR DESCRIPTION
Error handling: Make sure that if something breaks, the user can choose to address it somehow. I mainly cared about CRC checking because I occasionally saw garbage data.

Remove WProgram.h: This seems to be from an ancient version of Arduino and it breaks compilation when I embed this library in an ESP-IDF component (for the Espressif ESP32).