### PR TITLE
support optional autocalibration on begin.

### DIFF
--- a/examples/Example4_DisableCalibrate/Example4_DisableCalibrate.ino
+++ b/examples/Example4_DisableCalibrate/Example4_DisableCalibrate.ino
@@ -1,0 +1,61 @@
+/*
+  Reading CO2, humidity and temperature from the SCD30
+  By: Nathan Seidle
+  SparkFun Electronics
+  Date: May 22nd, 2018
+  License: MIT. See license file for more information but you can
+  basically do whatever you want with this code.
+
+  Feel like supporting open source hardware?
+  Buy a board from SparkFun! https://www.sparkfun.com/products/15112
+
+  This example turns off the auto-calibrate function during .begin()
+
+  Hardware Connections:
+  Attach RedBoard to computer using a USB cable.
+  Connect SCD30 to RedBoard using Qwiic cable.
+  Open Serial Monitor at 115200 baud.
+*/
+
+#include <Wire.h>
+
+#include "SparkFun_SCD30_Arduino_Library.h" //Click here to get the library: http://librarymanager/All#SparkFun_SCD30
+SCD30 airSensor;
+
+void setup()
+{
+    Serial.begin(115200);
+    Serial.println("SCD30 Example");
+    Wire.begin();
+
+    //Start sensor using the Wire port, but disable the auto-calibration
+    if (airSensor.begin(Wire, false) == false)
+    {
+        Serial.println("Air sensor not detected. Please check wiring. Freezing...");
+        while (1)
+            ;
+    }
+
+    //The SCD30 has data ready every two seconds
+}
+
+void loop()
+{
+    if (airSensor.dataAvailable())
+    {
+        Serial.print("co2(ppm):");
+        Serial.print(airSensor.getCO2());
+
+        Serial.print(" temp(C):");
+        Serial.print(airSensor.getTemperature(), 1);
+
+        Serial.print(" humidity(%):");
+        Serial.print(airSensor.getHumidity(), 1);
+
+        Serial.println();
+    }
+    else
+        Serial.println("Waiting for new data");
+
+    delay(500);
+}

--- a/src/SparkFun_SCD30_Arduino_Library.cpp
+++ b/src/SparkFun_SCD30_Arduino_Library.cpp
@@ -33,7 +33,7 @@ SCD30::SCD30(void)
 }
 
 //Initialize the Serial port
-bool SCD30::begin(TwoWire &wirePort)
+bool SCD30::begin(TwoWire &wirePort, bool autoCalibrate)
 {
   _i2cPort = &wirePort; //Grab which port the user wants us to use
 
@@ -58,7 +58,7 @@ bool SCD30::begin(TwoWire &wirePort)
   if (beginMeasuring() == true) //Start continuous measurements
   {
     setMeasurementInterval(2);    //2 seconds between measurements
-    setAutoSelfCalibration(true); //Enable auto-self-calibration
+    setAutoSelfCalibration(autoCalibrate); //Enable auto-self-calibration
 
     return (true);
   }

--- a/src/SparkFun_SCD30_Arduino_Library.h
+++ b/src/SparkFun_SCD30_Arduino_Library.h
@@ -49,8 +49,9 @@ class SCD30
 {
 public:
 	SCD30(void);
-
-	bool begin(TwoWire &wirePort = Wire); //By default use Wire port
+  
+	bool begin(bool autoCalibrate) { return begin(Wire, autoCalibrate); }
+	bool begin(TwoWire &wirePort = Wire, bool autoCalibrate=true); //By default use Wire port
 
 	bool beginMeasuring(uint16_t pressureOffset);
 	bool beginMeasuring(void);


### PR DESCRIPTION
Hi there,
 I have a usecase where I don't want the auto-calibration to ever happen on a sensor. So i'd prefer to have it disabled on begin(). Currently, begin always sets the autocalibration to true. 

This PR adds support for auto-calibration to be settable to false. It doesn't change the current behaviour. I.e., current code should work as-is.

Thanks,
Laban