### PR TITLE
Add 3ms delay before read sequence

### DIFF
--- a/src/SparkFun_SCD30_Arduino_Library.cpp
+++ b/src/SparkFun_SCD30_Arduino_Library.cpp
@@ -266,6 +266,8 @@ bool SCD30::readMeasurement()
   if (_i2cPort->endTransmission() != 0)
     return (0); //Sensor did not ACK
 
+  delay(3);
+
   const uint8_t receivedBytes = _i2cPort->requestFrom((uint8_t)SCD30_ADDRESS, (uint8_t)18);
   bool error = false;
   if (_i2cPort->available())
@@ -358,6 +360,8 @@ bool SCD30::getSettingValue(uint16_t registerAddress, uint16_t *val)
   if (_i2cPort->endTransmission() != 0)
     return (false); //Sensor did not ACK
 
+  delay(3);
+
   _i2cPort->requestFrom((uint8_t)SCD30_ADDRESS, (uint8_t)3); // Request data and CRC
   if (_i2cPort->available())
   {
@@ -388,6 +392,8 @@ uint16_t SCD30::readRegister(uint16_t registerAddress)
   _i2cPort->write(registerAddress & 0xFF); //LSB
   if (_i2cPort->endTransmission() != 0)
     return (0); //Sensor did not ACK
+
+  delay(3);
 
   _i2cPort->requestFrom((uint8_t)SCD30_ADDRESS, (uint8_t)2);
   if (_i2cPort->available())


### PR DESCRIPTION
Wait time of 3ms is required before read sequence.
See page 4 of "Interface Description SCD30".
![2021-05-05 234740](https://user-images.githubusercontent.com/2385465/117160694-4c654080-adfc-11eb-9b7a-8a27f2e63b2e.jpg)