### PR TITLE
byte uint8_t issue for ESP8266 version 3

### DIFF
--- a/src/SparkFun_SCD30_Arduino_Library.cpp
+++ b/src/SparkFun_SCD30_Arduino_Library.cpp
@@ -310,10 +310,10 @@ bool SCD30::readMeasurement()
   bool error = false;
   if (_i2cPort->available())
   {
-    byte bytesToCrc[2];
-    for (byte x = 0; x < 18; x++)
+    uint8_t bytesToCrc[2];
+    for (uint8_t x = 0; x < 18; x++)
     {
-      byte incoming = _i2cPort->read();
+      uint8_t incoming = _i2cPort->read();
 
       switch (x)
       {

--- a/src/SparkFun_SCD30_Arduino_Library.h
+++ b/src/SparkFun_SCD30_Arduino_Library.h
@@ -59,7 +59,7 @@
 
 typedef union
 {
-	byte array[4];
+	uint8_t array[4];
 	float value;
 } ByteToFl; // paulvha
 


### PR DESCRIPTION
Arduino Board EPS8266 version 3.x does not compile when a variable is declared as byte. 
This changes occurrences of byte to uint8_t