### PR TITLE
Properly initialize Wire on ESP32

### DIFF
--- a/src/SparkFun_SCD30_Arduino_Library.cpp
+++ b/src/SparkFun_SCD30_Arduino_Library.cpp
@@ -41,6 +41,9 @@ bool SCD30::begin(TwoWire &wirePort, bool autoCalibrate, bool measBegin)
 {
   _i2cPort = &wirePort; // Grab which port the user wants us to use
 
+  #ifndef USE_TEENSY3_I2C_LIB
+  _i2cPort->begin();
+  #endif
   /* Especially during obtaining the ACK BIT after a byte sent the SCD30 is using clock stretching  (but NOT only there)!
    * The need for clock stretching is described in the Sensirion_CO2_Sensors_SCD30_Interface_Description.pdf
    *


### PR DESCRIPTION
`Wire` now seems to require method `begin()` to be called before `beginTransmission()`. This patch accomodates such new requirement by executing `_i2cPort->begin();` if `Wire` is used.

Tested on Lolin32, and can confirm it works now with the fix. Not sure if this change should be specifically applied for ESP32, or can be generalized to non-TEENSY3_I2C implementations.


## Error message
```
[581391][E][Wire.cpp:422] beginTransmission(): could not acquire lock
[581392][E][Wire.cpp:526] write(): NULL TX buffer pointer
[581392][E][Wire.cpp:448] endTransmission(): NULL TX buffer pointer
[581398][E][Wire.cpp:481] requestFrom(): NULL buffer pointer
```

## Related links
https://community.platformio.org/t/updating-espressif-32-to-5-2-0-breaks-wire-cpp/30282/2
https://github.com/espressif/arduino-esp32/commit/9bceb280e3a53492278dddf08fadcf540549dcdf
https://github.com/espressif/arduino-esp32/blob/master/libraries/Wire/src/Wire.cpp#L278-L308
